### PR TITLE
Handle paths with spaces when pulling from remote

### DIFF
--- a/Support/hg_pull.rb
+++ b/Support/hg_pull.rb
@@ -13,7 +13,7 @@ TextMate::call_with_progress(:title => "Pull from default repos.",
                            :message => "Accessing Parent Repository…",
                            :output_filepath => nil) do
 
-   `cd #{work_path};#{hg} pull`
+   `cd "#{work_path}";#{hg} pull`
 
 end
 


### PR DESCRIPTION
Quotes were missing around directory path.